### PR TITLE
Add ruGPT-3.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,48 @@
 Using model Qwen2-0.5B
 
 Vocab size is 151936
+
+## Added support for ruGPT-3.5 model
+
+Using model ruGPT-3.5
+
+Example usage:
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+model_choice = "rugpt"  # Change this to "qwen" or "rugpt" as needed
+
+if model_choice == "qwen":
+    model_name = "Qwen/Qwen2-0.5B"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype=torch.bfloat16
+    )
+    model.eval()
+
+    input_text = (
+        "<|im_end|>system\nYou are a storyteller. Generate a story based on user message.<|im_end|>\n"
+        "<|im_end|>user\nGenerate me a short story about a tiny hedgehog named Sonic.<|im_end|>\n"
+        "<|im_end|>assistant\n"
+    )
+
+elif model_choice == "rugpt":
+    model_name = "ai-forever/rugpt3.5"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    model.eval()
+
+    input_text = "Сгенерируй короткую историю про маленького ежа по имени Соник:\n"
+
+else:
+    raise ValueError("Unknown model choice. Use 'qwen' or 'rugpt'.")
+
+inputs = tokenizer(input_text, return_tensors="pt").to("cpu")
+
+with torch.no_grad():
+    logits = model(**inputs).logits
+    print(f"Logits shape: {logits.shape}")
+```

--- a/main.py
+++ b/main.py
@@ -1,22 +1,36 @@
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import torch
 
-from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig
+model_choice = "rugpt"  # Change this to "qwen" or "rugpt" as needed
 
-tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2-0.5B") 
-model = AutoModelForCausalLM.from_pretrained(
-    "Qwen/Qwen2-0.5B",
-    torch_dtype=torch.bfloat16
-)
-model.eval()
-input_text_hedgehog = '<|im_start|>system\nYou are a storyteller. Generate a story based on user message.<|im_end|>\n<|im_start|>user\nGenerate me a short story about a tiny hedgehog named Sonic.<|im_end|>\n<|im_start|>assistant\n'
-input_text_json = '<|im_start|>system\nYou are a JSON machine. Generate a JSON with format {"contractor": string with normalized contractor name, "sum": decimal, "currency": string with uppercased 3-letter currency code} based on user message.<|im_end|>\n<|im_start|>user\nTransfer 100 rubles and 50 kopeck to Mike<|im_end|>\n<|im_start|>assistant\n'
+if model_choice == "qwen":
+    model_name = "Qwen/Qwen2-0.5B"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype=torch.bfloat16
+    )
+    model.eval()
 
-inputs = tokenizer(input_text_hedgehog, return_tensors="pt").to("cpu") 
+    input_text = (
+        "<|im_end|>system\nYou are a storyteller. Generate a story based on user message.<|im_end|>\n"
+        "<|im_end|>user\nGenerate me a short story about a tiny hedgehog named Sonic.<|im_end|>\n"
+        "<|im_end|>assistant\n"
+    )
+
+elif model_choice == "rugpt":
+    model_name = "ai-forever/rugpt3.5"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    model.eval()
+
+    input_text = "Сгенерируй короткую историю про маленького ежа по имени Соник:\n"
+
+else:
+    raise ValueError("Unknown model choice. Use 'qwen' or 'rugpt'.")
+
+inputs = tokenizer(input_text, return_tensors="pt").to("cpu")
 
 with torch.no_grad():
-    logits = model( 
-    **inputs
-        ).logits
-
-    print(logits.shape)
+    logits = model(**inputs).logits
+    print(f"Logits shape: {logits.shape}")


### PR DESCRIPTION
Fixes #1

Add support for ruGPT-3.5 model.

* **main.py**
  - Add conditional logic to select between Qwen and ruGPT models.
  - Add support for ruGPT-3.5 model.
  - Update input text for ruGPT model.

* **README.md**
  - Update to mention support for ruGPT-3.5 model.
  - Add example usage for ruGPT-3.5 model.

---

